### PR TITLE
Ensure that `BuiltinAdministrators` also have access to files chmod'd by `LOCAL_SYSTEM`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,20 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v4
+
       - name: pester
         run: Invoke-Pester -Show All
+
       - name: Install go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+
       - name: go test
         run: go test -v ./...
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.56
+          args: --timeout=10m
+          version: v1.59

--- a/pkg/filemode/convert.go
+++ b/pkg/filemode/convert.go
@@ -50,5 +50,13 @@ func (m AccessMasks) ToExplicitAccessCustom(owner, group *windows.SID) []windows
 		ea = append(ea, access.GrantSid(m.Everyone, everyone))
 	}
 
+	if owner.IsWellKnown(windows.WinLocalSystemSid) && group.IsWellKnown(windows.WinLocalSystemSid) {
+		// If both the owner and group are LOCAL_SYSTEM, we need to ensure that the BuiltinAdministrators group
+		// also has access to the file. This is needed as the LOCAL_SYSTEM user and group cannot be used by other accounts,
+		// so we would be effectively blocking all human access to the file. sid.CurrentUser and sid.CurrentGroup
+		// will always return LOCAL_SYSTEM when this function is invoked by a Windows service
+		ea = append(ea, access.GrantSid(m.Owner, sid.BuiltinAdministrators()))
+	}
+
 	return ea
 }


### PR DESCRIPTION
If a Windows service running as the Local System invokes `chmod` then no other accounts will be able to access or modify the file. This is because a service running as Local System will have both the owner and group set to Local System. As other users cannot login as Local System, the file will become inaccessible. This PR ensures that, if the owner and group are Local System, then built in administrators will also have access to the file. This ensures that user accounts can still access this file, in accordance with the permission bits provided to `chmod`