### PR TITLE
Ensure that files chmod'd by Local System can still be accessed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,15 +22,20 @@ jobs:
     steps:
       - name: Run checkout
         uses: actions/checkout@v4
+
       - name: pester
         run: Invoke-Pester -Show All
-      - name: Install go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 'stable'
+
+      - name: Install Security Module
+        run: Import-Module Microsoft.PowerShell.Security
+
       - name: go test
-        run: go test -v ./...
+        run: |
+          $env:PSModulePath = ''
+          go test -v ./...
+
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.56
+          args: --timeout=10m
+          version: v1.59

--- a/.golangci.json
+++ b/.golangci.json
@@ -10,9 +10,6 @@
 			"gofmt"
 		]
 	},
-	"run": {
-		"deadline": "5m"
-	},
     "issues": {
         "exclude-rules": []
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/permissions
 
-go 1.21
+go 1.22.0
+
+toolchain go1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/pkg/filemode/convert.go
+++ b/pkg/filemode/convert.go
@@ -50,5 +50,13 @@ func (m AccessMasks) ToExplicitAccessCustom(owner, group *windows.SID) []windows
 		ea = append(ea, access.GrantSid(m.Everyone, everyone))
 	}
 
+	if owner.IsWellKnown(windows.WinLocalSystemSid) && group.IsWellKnown(windows.WinLocalSystemSid) {
+		// If both the owner and group are LOCAL_SYSTEM, we need to ensure that the BuiltinAdministrators group
+		// also has access to the file. This is needed as the LOCAL_SYSTEM user and group cannot be used by other accounts,
+		// so we would be effectively blocking all human access to the file. sid.CurrentUser and sid.CurrentGroup
+		// will always return LOCAL_SYSTEM when this function is invoked by a Windows service
+		ea = append(ea, access.GrantSid(m.Owner, sid.BuiltinAdministrators()))
+	}
+
 	return ea
 }

--- a/src/Permissions.Tests.ps1
+++ b/src/Permissions.Tests.ps1
@@ -4,6 +4,9 @@ BeforeAll {
         "$PSScriptRoot\Permissions.psm1"
     ) -WarningAction Ignore -Force    
 
+    # Add security module
+    Import-Module Microsoft.PowerShell.Security
+
     # Defaults
     $tempFile = New-TemporaryFile
     $DefaultOwner, $DefaultGroup, $DefaultPermissions = Get-Permissions $tempFile.FullName


### PR DESCRIPTION
This PR updates how the permissions repository generates `EXPLICIT_ACCESS` entries when no user or group is provided. Previously, if a Windows service was invoking `chmod`, then the user and group values obtained within `toExplicitAccessCustom` would both be equal to the Local System Sid. This is a problem, as other accounts cannot be added to the Local System group, and users cannot login as Local System. By only including Local System, other accounts are locked out of the file. After this change, the build in administrators group will always be added to files being modified by the Local System.

This PR also fixes up the CI to work on gha