### PR TITLE
Remove 2019 CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Run checkout


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/50500

GHA is dropping support for windows-2019 on June 30th, so we need to remove it from our testing CI. Since we're still testing against 2022 we aren't losing much coverage. 